### PR TITLE
Fix ignore null epsg from lipac

### DIFF
--- a/tests/tests_pacasam/test_run_extraction.py
+++ b/tests/tests_pacasam/test_run_extraction.py
@@ -7,7 +7,7 @@ import glob
 
 @pytest.mark.timeout(60)
 @pytest.mark.slow
-@pytest.mark.geoportail  # This tests requests the geoportail
+@pytest.mark.geoportail
 def test_run_extraction_laz(toy_sampling_file):
     """Run them
 


### PR DESCRIPTION
Pour prendre en compte que EPSG:0 doit signifier un SRID inconnu dans une base de données.
Cf. https://github.com/IGNF/panini/issues/1 (privé)