### PR TITLE
Mpire parallelization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Run Extraction (orthoimagery forest)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/pacasam/run_extraction.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "--sampling_path=/home/CGaydon/repositories/multimodal-tree-classification-dataset/outputs/Store-Analyse-outputs/tmp_local/20230830_PureForestStandDataset-Patches-Labeled-BDF12C-WithPath-Split.gpkg",
+                "--dataset_root_path=/mnt/store-lidarhd/projet-LHD/IA/PACASAM-SHARED-WORKSPACE/CGaydon/20230830_PureForestStandDataset/imagery/",
+                "--extractor_class=OrthoimagesExtractor"
+            ]
+        },
+        {
             "name": "Run Pytest",
             "type": "python",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,22 @@
             "args": [
                 "--sampling_path=/home/CGaydon/repositories/multimodal-tree-classification-dataset/outputs/Store-Analyse-outputs/tmp_local/20230830_PureForestStandDataset-Patches-Labeled-BDF12C-WithPath-Split.gpkg",
                 "--dataset_root_path=/mnt/store-lidarhd/projet-LHD/IA/PACASAM-SHARED-WORKSPACE/CGaydon/20230830_PureForestStandDataset/imagery/",
-                "--extractor_class=OrthoimagesExtractor"
+                "--extractor_class=OrthoimagesExtractor",
+                "--n_jobs=1"
+            ]
+        },
+        {
+            "name": "Run Extraction (laz forest)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/pacasam/run_extraction.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "--sampling_path=/home/CGaydon/repositories/multimodal-tree-classification-dataset/outputs/Store-Analyse-outputs/tmp_local/20230830_PureForestStandDataset-Patches-Labeled-BDF12C-WithPath-Split.gpkg",
+                "--dataset_root_path=/mnt/store-lidarhd/projet-LHD/IA/PACASAM-SHARED-WORKSPACE/CGaydon/20230830_PureForestStandDataset/debug_mode/",
+                "--extractor_class=LAZExtractor",
+                "--n_jobs=1",
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
             "args": [
                 "-s",
                 "-k",
-                "test_run_extraction_orthoimages",
+                "test_run_extraction_laz",
             ],
             "env": {
                 "PYTEST_ADDOPTS": "--no-cov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+# 0.10.0
+- Parallelize extractions using MPIRE instead of GNU-parallel
+
 # 0.9.1
 - Update ign-pdal-tools version dependency to avoid cluttered /tmp/ folder.
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ help:
 	@echo "  all_synthetic - Exécute tous les samplers pour le connecteur synthétique"
 	@echo "------------------------------------"
 	@echo "Cibles pour l'extraction:"
+	@echo "  extract_dataset - Extrait un dataset."
 	@echo "  extract_toy_laz_data - Vérifie que tout est OK en extrayant depuis les données LAZ de test."
 	@echo "  extract_toy_orthoimages_data - Vérifie que tout est OK en extrayant des orthoimages."
 	@echo "  _prepare_parallel_extraction - Divise un sampling `SAMPLING_PATH` en n sampling, un par fichier (p.ex. par fichier LAZ), dans SAMPLING_PARTS_DIR."

--- a/README.md
+++ b/README.md
@@ -133,29 +133,32 @@ L'échantillonnage est visualisable dans un SIG, p.ex. QGIS.
 
 6. Lancer l'extraction du jeu de données : extraction des patches et colorisation IRC
 
-Pour tester l'extraction sur le jeu de données de test, lancer
+Quick run: extractions sur le jeu de données de test :
+
 ```bash
 conda activate pacasam
-make extract_toy_laz_data
-make extract_toy_laz_data_in_parallel  # multiprocesses via parallel
+make extract_toy_orthoimages_data  # "./outputs/extractions/toy_orthoimages_dataset/"
+make extract_toy_laz_data  # "./outputs/extractions/toy_laz_dataset/"
 ```
 
 Passons maintenant à une extraction depuis un sampling Lipac. 
 Si les chemins vers les fichiers LAZ correspondent à un data store Samba, il faut préciser vos informations de connexion via les variables d'environnement `SAMBA_USERNAME` (au format username@domain) et `SAMBA_PASSWORD`.
 
-Pour lancer l'extraction de façon parallélisée à partir du sampling "Triple" à l'emplacement par défaut:
+Pour lancer l'extraction de façon parallélisée (15 processeurs) à partir du sampling "Triple" à l'emplacement par défaut:
 
 ```bash
 conda activate pacasam
-make extract_laz_dataset_parallel \
-    SAMPLING_PATH="outputs/samplings/LiPaCConnector-TripleSampler/LiPaCConnector-TripleSampler-train.gpkg" \
-    SAMPLING_PARTS_DIR="/tmp/my_laz_dataset_parts/" \
-    DATASET_ROOT_PATH="/var/data/${USER}/pacasam_extractions/laz_dataset/" \
-    PARALLEL_EXTRACTION_JOBS="50%" \
-    USE_SAMBA="Y"
+export SAMPLING_PATH="outputs/samplings/LiPaCConnector-TripleSampler/LiPaCConnector-TripleSampler-train.gpkg"
+export DATASET_ROOT_PATH="/var/data/${USER}/pacasam_extractions/laz_dataset/"
+export PARALLEL_EXTRACTION_JOBS=15
+export EXTRACTOR_CLASS="LAZExtractor"
+export USE_SAMBA="Y"
+python ./src/pacasam/run_extraction.py \
+    --sampling_path ${SAMPLING_PATH} \
+    --dataset_root_path ${DATASET_ROOT_PATH} \
+    --extractor_class ${EXTRACTOR_CLASS} \
+    --n_jobs ${PARALLEL_EXTRACTION_JOBS}
 ```
-
-Note: sous le capot, le sampling initial est divisé en autant de parties qu'il y a de fichiers LAZ initiaux concernés. Cette étape préliminaire permet une parallélisation au niveau du fichier sans changement du code d'extraction. La parallélisation est effectuée avec (`GNU parallel`)[https://www.gnu.org/software/parallel/parallel.html].
 
 ### Jeu d'apprentissage et jeu de test
 
@@ -189,6 +192,8 @@ NB: un timeout d'une minute est appliqué aux tests impliquant le géoportail.
 Passage à l'échelle OK : Tests avec 4M de vignettes (et ~20 variables) sur machine locale avec 7.2GB de RAM -> taille totale en mémoire de 600MB environ pour 4M de vignettes. Le sampling FPS se fait par parties si nécessaires p.ex. par 20k vignettes successives.
 
 Pacasam ne permet que d'extraire des vignettes carrées, et alignées avec les axes X et Y du système de coordonnées de référence.
+
+
 
 ### Pistes pour améliorer les samplers
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ Passage à l'échelle OK : Tests avec 4M de vignettes (et ~20 variables) sur mac
 
 Pacasam ne permet que d'extraire des vignettes carrées, et alignées avec les axes X et Y du système de coordonnées de référence.
 
-
-
 ### Pistes pour améliorer les samplers
 
 - Assurer la spatialisation de FPS dans DiversitySampler. Actuellement : traitement par parties spatialisé : on ordonne par file_id et patch_id, puis les parties peuvent faire a minima 20000 patches, soit 50 dalles. On pourra ordonner par bloc_id également dans le futur, et augmenter la taille des chunks.

--- a/environment.yml
+++ b/environment.yml
@@ -34,8 +34,8 @@ dependencies:
   - pytest-timeout  
   - pytest-xdist  # tests parallelization using `pytest -n NUM_CPUs`
   # --------- dependencies for ign-pdal-tools - they currently need explicit installation  ----------- #
-  - conda-forge:pdal==2.5.*
-  - conda-forge:python-pdal==3.2.*
+  - conda-forge:pdal==2.5.6
+  - conda-forge:python-pdal==3.2.3
   - requests
   - gdal
   - pip:

--- a/src/pacasam/_version.py
+++ b/src/pacasam/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 
 
 if __name__ == "__main__":

--- a/src/pacasam/extractors/extractor.py
+++ b/src/pacasam/extractors/extractor.py
@@ -16,17 +16,12 @@ DEFAULT_SRID_LAMBERT93 = "2154"  # Assume Lambert93 if we cannot infer srid from
 class Extractor:
     """Abstract class defining extractor interface."""
 
-    def __init__(
-        self,
-        log: logging.Logger,
-        sampling_path: Path,
-        dataset_root_path: Path,
-        use_samba: bool = False,
-    ):
+    def __init__(self, log: logging.Logger, sampling_path: Path, dataset_root_path: Path, use_samba: bool = False, n_jobs: int = 1):
         """Initializes the extractor. Always loads the sampling with sanity checks on format."""
         self.log = log
         self.name: str = self.__class__.__name__
         self.dataset_root_path = dataset_root_path
+        self.n_jobs = n_jobs  # parallelization
         # Wether to use samba client or use the local filesystem.
         if use_samba:
             set_smb_client_singleton()

--- a/src/pacasam/extractors/laz.py
+++ b/src/pacasam/extractors/laz.py
@@ -40,6 +40,7 @@ Read and check the sampling geopackage:
 """
 
 
+import os
 from pathlib import Path
 import tempfile
 from typing import Optional, Union
@@ -137,4 +138,12 @@ def colorize_single_patch(nocolor_patch: Union[str, Path], colorized_patch: Unio
     if isinstance(colorized_patch, str):
         colorized_patch = Path(colorized_patch)
 
-    color(str(nocolor_patch.resolve()), str(colorized_patch.resolve()), proj=str(srid))
+    tmp_ortho, tmp_ortho_irc = color(str(nocolor_patch.resolve()), str(colorized_patch.resolve()), proj=str(srid))
+    # tmp fix bc for now those are string objects !
+    try:
+        # for V1.3.0 of ign-pdal-tools
+        os.remove(tmp_ortho)
+        os.remove(tmp_ortho_irc)
+    except:
+        # for V1.3.1 of ign-pdal-tools
+        pass

--- a/src/pacasam/extractors/laz.py
+++ b/src/pacasam/extractors/laz.py
@@ -40,7 +40,6 @@ Read and check the sampling geopackage:
 """
 
 
-import os
 from pathlib import Path
 import tempfile
 from typing import Optional, Union
@@ -138,12 +137,4 @@ def colorize_single_patch(nocolor_patch: Union[str, Path], colorized_patch: Unio
     if isinstance(colorized_patch, str):
         colorized_patch = Path(colorized_patch)
 
-    tmp_ortho, tmp_ortho_irc = color(str(nocolor_patch.resolve()), str(colorized_patch.resolve()), proj=str(srid))
-    # tmp fix bc for now those are string objects !
-    try:
-        # for V1.3.0 of ign-pdal-tools
-        os.remove(tmp_ortho)
-        os.remove(tmp_ortho_irc)
-    except:
-        # for V1.3.1 of ign-pdal-tools
-        pass
+    color(str(nocolor_patch.resolve()), str(colorized_patch.resolve()), proj=str(srid))

--- a/src/pacasam/extractors/orthoimages.py
+++ b/src/pacasam/extractors/orthoimages.py
@@ -21,7 +21,7 @@ from pacasam.connectors.connector import GEOMETRY_COLNAME, PATCH_ID_COLNAME, SRI
 from pacasam.extractors.extractor import Extractor, DEFAULT_SRID_LAMBERT93
 from pacasam.samplers.sampler import SPLIT_COLNAME
 import rasterio
-from mpire import WorkerPool, cpu_count
+from mpire import WorkerPool
 
 
 class OrthoimagesExtractor(Extractor):
@@ -35,7 +35,7 @@ class OrthoimagesExtractor(Extractor):
         """Download the orthoimages dataset."""
         # mpire does argument unpacking, see https://github.com/sybrenjansen/mpire/issues/29#issuecomment-984559662.
         patch_infos = [(patch_info,) for _, patch_info in self.sampling.iterrows()]
-        with WorkerPool(n_jobs=cpu_count() // 4) as pool:
+        with WorkerPool(n_jobs=self.n_jobs) as pool:
             pool.map(self.extract_single_patch, patch_infos, progress_bar=True)
 
     def extract_single_patch(self, patch_info):

--- a/src/pacasam/run_extraction.py
+++ b/src/pacasam/run_extraction.py
@@ -41,6 +41,13 @@ parser.add_argument(
     "--extractor_class", default="LAZExtractor", type=str, help=("Name of class of Extractor to use."), choices=EXTRACTORS_LIBRARY.keys()
 )
 
+parser.add_argument(
+    "--n_jobs",
+    default=1,
+    type=int,
+    help="Num of processors to use for parallelization of the extraction with MPIRE.",
+)
+
 
 def run_extraction(args):
     set_log_text_handler(log, args.dataset_root_path)
@@ -51,10 +58,16 @@ def run_extraction(args):
     log.info(f"EXTRACTOR CLASS: {args.extractor_class}")
     if args.extractor_class == "LAZExtractor":
         extractor: Extractor = LAZExtractor(
-            log=log, sampling_path=args.sampling_path, dataset_root_path=args.dataset_root_path, use_samba=args.samba_filesystem
+            log=log,
+            sampling_path=args.sampling_path,
+            dataset_root_path=args.dataset_root_path,
+            use_samba=args.samba_filesystem,
+            n_jobs=args.n_jobs,
         )
     elif args.extractor_class == "OrthoimagesExtractor":
-        extractor: Extractor = OrthoimagesExtractor(log=log, sampling_path=args.sampling_path, dataset_root_path=args.dataset_root_path)
+        extractor: Extractor = OrthoimagesExtractor(
+            log=log, sampling_path=args.sampling_path, dataset_root_path=args.dataset_root_path, n_jobs=args.n_jobs
+        )
     else:
         raise ValueError(f"Extractor {args.extractor_class} is unknown. See argparse choices with --help.")
     extractor.extract()


### PR DESCRIPTION
Je propose une parallélisation de l'extraction de jeux de données (laz/orthoimages), qui n'oblige pas à passer par une découpe du sampling (.gpkg). 
Il est toujours possible de passer par cette découpe pour e.g. une GPAO, mais c'était complexe et ça n'a pas à être la méthode par défaut.