### PR TITLE
Simple safeguard for potential redundancy of data in LiPaC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+# 0.9.2
+- Drop duplicates patches by patch_id right after download to anticipate potential duplicates in Lipac.
+
 # 0.9.1
 - Update ign-pdal-tools version dependency to avoid cluttered /tmp/ folder.
 

--- a/src/pacasam/_version.py
+++ b/src/pacasam/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 
 if __name__ == "__main__":

--- a/src/pacasam/connectors/lipac.py
+++ b/src/pacasam/connectors/lipac.py
@@ -94,6 +94,7 @@ class LiPaCConnector(Connector):
         gdf: gpd.GeoDataFrame = pd.concat(chunks)
         gdf = gdf.set_crs(self.lambert_93_crs)
         gdf = gdf.sort_values(by=PATCH_ID_COLNAME)
+        gdf = gdf.drop_duplicates(subset=PATCH_ID_COLNAME)
         return gdf
 
 


### PR DESCRIPTION
Lié à une erreur de design de Lipac, qui peut avoir des conséquences si on sort de ses hypothèses de création.
Cf. cette description

> Par conception, la base impose l’unicité (version_de_reference== true) par couple bloc-dalle. Mais aujourd’hui, on peut insérer en base deux « dalles » de même emprise si elles sont liées à 2 blocs différents (en raison d’une évolution de la limite de bloc entre les 2 insertions, par exemple). 
> Cette éventualité n’est pas si abstraite : on peut imaginer un bloc AA, complet. Puis un partenaire qui accepte de financer AB à condition qu’on dépasse de quelques km² (sur AA) pour que l’ensemble de son territoire soit couvert à une même date. Dans ce cas, sur quelques kilomètres carrés, on aurait des dalles sur XXXX_YYYY acquises à T1 liées à AA et acquises à T2 liées à AB. A ce niveau-là, le bloc peut d’ailleurs être associé à un chantier. 

