### PR TITLE
Log the pacasam version and the git commit SHA when doing a sampling …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+# 0.10.2
+- Log the pacasam version and the git commit SHA when doing a sampling or an extraction.
+
 ### 0.10.1
 - Add tests for run_sampling with LipacConnector, to run locally.
 

--- a/environment.yml
+++ b/environment.yml
@@ -43,3 +43,4 @@ dependencies:
     - laspy[lazrs,laszip]==2.1.*  # laspy with LAZ backend support
     - ign-pdal-tools==1.3.1  # for colorization of LAZ files
     - python-dotenv
+    - gitpython

--- a/src/pacasam/run_extraction.py
+++ b/src/pacasam/run_extraction.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import argparse
+import git
 
 
 root_dir = Path(__file__).resolve().parent.parent
@@ -13,7 +14,10 @@ from pacasam.extractors.laz import LAZExtractor
 from pacasam.extractors.bd_ortho_today import BDOrthoTodayExtractor
 from pacasam.extractors.bd_ortho_vintage import BDOrthoVintageExtractor
 from pacasam.utils import EXTRACTORS_LIBRARY, set_log_text_handler, setup_custom_logger
+from _version import __version__
 
+repo = git.Repo(search_parent_directories=True)
+sha = repo.head.object.hexsha  # Git SHA to track the exact version of the code.
 log = setup_custom_logger()
 
 # PARAMETERS
@@ -48,6 +52,7 @@ parser.add_argument("--num_jobs", default=1, type=int, help="Number of processes
 def run_extraction(args):
     set_log_text_handler(log, args.dataset_root_path)
     log.info("Extraction of a dataset using pacasam (https://github.com/IGNF/pacasam).\n")
+    log.info(f"Pacasam version is {__version__} at commit https://github.com/IGNF/pacasam/tree/{sha}.\n")
     log.info(f"COMMAND: {' '.join(sys.argv)}")
     log.info(f"SAMPLING GEOPACKAGE: {args.sampling_path}")
     log.info(f"OUTPUT DATASET DIR: {args.dataset_root_path}")

--- a/src/pacasam/run_extraction.py
+++ b/src/pacasam/run_extraction.py
@@ -14,7 +14,7 @@ from pacasam.extractors.laz import LAZExtractor
 from pacasam.extractors.bd_ortho_today import BDOrthoTodayExtractor
 from pacasam.extractors.bd_ortho_vintage import BDOrthoVintageExtractor
 from pacasam.utils import EXTRACTORS_LIBRARY, set_log_text_handler, setup_custom_logger
-from _version import __version__
+from pacasam._version import __version__
 
 repo = git.Repo(search_parent_directories=True)
 sha = repo.head.object.hexsha  # Git SHA to track the exact version of the code.

--- a/src/pacasam/run_sampling.py
+++ b/src/pacasam/run_sampling.py
@@ -13,7 +13,7 @@ from pacasam.utils import CONNECTORS_LIBRARY, SAMPLERS_LIBRARY, set_log_text_han
 from pacasam.analysis.stats import Comparer
 from pacasam.connectors.connector import Connector
 from pacasam.samplers.sampler import Sampler, save_gpd_to_any_filesystem
-from _version import __version__
+from pacasam._version import __version__
 
 repo = git.Repo(search_parent_directories=True)
 sha = repo.head.object.hexsha  # Git SHA to track the exact version of the code.

--- a/src/pacasam/run_sampling.py
+++ b/src/pacasam/run_sampling.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import geopandas as gpd
 import yaml
 from dotenv import load_dotenv
-
-load_dotenv()
+import argparse
+import git
 
 root_dir = Path(__file__).resolve().parent.parent
 sys.path.append(str(root_dir))
@@ -13,18 +13,18 @@ from pacasam.utils import CONNECTORS_LIBRARY, SAMPLERS_LIBRARY, set_log_text_han
 from pacasam.analysis.stats import Comparer
 from pacasam.connectors.connector import Connector
 from pacasam.samplers.sampler import Sampler, save_gpd_to_any_filesystem
+from _version import __version__
 
+repo = git.Repo(search_parent_directories=True)
+sha = repo.head.object.hexsha  # Git SHA to track the exact version of the code.
+load_dotenv()
 log = setup_custom_logger()
 
 # PARAMETERS
-import argparse
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--config_file", default="configs/Lipac.yml", type=lambda p: Path(p).absolute())
-
 parser.add_argument("--connector_class", default="LiPaCConnector", choices=CONNECTORS_LIBRARY.keys())
 parser.add_argument("--sampler_class", default="TripleSampler", choices=SAMPLERS_LIBRARY.keys())
-
 parser.add_argument("--output_path", default=None)
 
 
@@ -37,6 +37,7 @@ def run_sampling(args):
     # Prepare logging
     set_log_text_handler(log, args.output_path)
     log.info("Performing a sampling with pacasam (https://github.com/IGNF/pacasam).\n")
+    log.info(f"Pacasam version is {__version__} at commit https://github.com/IGNF/pacasam/tree/{sha}.\n")
     log.info(f"COMMAND: {' '.join(sys.argv)}")
     conf = load_sampling_config(args.config_file)
     log.info(f"CONFIGURATION FILE: {args.config_file}")


### PR DESCRIPTION
…or an extraction.

Pour https://github.com/IGNF/pacasam/issues/45.
Je n'ai pas trouvé de moyen propre de sauvegarder la requete SQL, comme c'est quelque chose de très spécifique à l'extracteur LiPaC. Mais en donnant le sha on donne directement accès à la requete dans un format fichier, si le besoin s'en faisait ressortir.
Pour rappel la requête sql est aussi dumpée dans les logs.