### PR TITLE
fix: Use shutil.copy instead of shutil.move to avoid invalid cross-device link error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # main
 
-# 0.10.2
+### 0.10.3
+- fix: Use shutil.copy instead of shutil.move to avoid invalid cross-device link error.
+
+### 0.10.2
 - Log the pacasam version and the git commit SHA when doing a sampling or an extraction.
 
 ### 0.10.1

--- a/src/pacasam/_version.py
+++ b/src/pacasam/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.1"
+__version__ = "0.10.3"
 
 
 if __name__ == "__main__":

--- a/src/pacasam/extractors/bd_ortho_today.py
+++ b/src/pacasam/extractors/bd_ortho_today.py
@@ -63,7 +63,7 @@ class BDOrthoTodayExtractor(Extractor):
             tmp_patch: tempfile._TemporaryFileWrapper = tempfile.NamedTemporaryFile(suffix=self.patch_suffix, prefix="extracted_patch")
             self.collate_rgbnir_and_save(tmp_ortho_rgb.name, tmp_ortho_nir.name, tmp_patch)
             tiff_patch_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(tmp_patch.name, tiff_patch_path)
+            shutil.copy(tmp_patch.name, tiff_patch_path)
 
     def get_orthoimages_for_patch(self, patch_bounds: tuple, srid: str, tmp_ortho_rgb: str, tmp_ortho_nir: str):
         """Request RGB and NIR-Color orthoimages,"""

--- a/src/pacasam/extractors/bd_ortho_vintage.py
+++ b/src/pacasam/extractors/bd_ortho_vintage.py
@@ -100,7 +100,7 @@ class BDOrthoVintageExtractor(Extractor):
                 tmp_patch: tempfile._TemporaryFileWrapper = tempfile.NamedTemporaryFile(suffix=self.patch_suffix, prefix="extracted_patch")
                 collate_rgbnir_and_save(options, rvb_arr, irc_arr, tmp_patch)
                 tiff_patch_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(tmp_patch.name, tiff_patch_path)
+                shutil.copy(tmp_patch.name, tiff_patch_path)
 
 
 def extract_patch_as_geotiffs(src_orthoimagery: DatasetReader, patch_geometry: Tuple, num_pixels: int):

--- a/src/pacasam/extractors/laz.py
+++ b/src/pacasam/extractors/laz.py
@@ -118,7 +118,7 @@ class LAZExtractor(Extractor):
             srid = getattr(patch_info, SRID_COLNAME, None)
             colorize_single_patch(nocolor_patch=Path(tmp_patch.name), colorized_patch=Path(tmp_patch.name), srid=srid)
             colorized_patch.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(tmp_patch.name, colorized_patch)
+            shutil.copy(tmp_patch.name, colorized_patch)
 
 
 def extract_single_patch_from_LasData(cloud: LasData, header: LasHeader, patch_bounds) -> tempfile._TemporaryFileWrapper:


### PR DESCRIPTION
Comme on copie des fichiers temporaires le résultat est le même, et on évite l'erreur décrite [dans ce post stackoverflow](https://stackoverflow.com/a/43967659/8086033).